### PR TITLE
adds definition of a Coverage build type

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -53,7 +53,6 @@ IF(NOT CMAKE_COMPILER_IS_GNUCXX)
 	ENDIF()
 ENDIF() # NOT CMAKE_COMPILER_IS_GNUCXX
 
-message("* Adding build types...")
 SET(CMAKE_CXX_FLAGS_COVERAGE
     "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
     CACHE STRING "Flags used by the C++ compiler during coverage builds."


### PR DESCRIPTION
I added the definition of a separate Coverage build type, in order not to modify the Debug one when you do not want to.
