### PR TITLE
Feature/lcov remove extra

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -102,6 +102,10 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 		MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
 	ENDIF() # NOT GENHTML_PATH
 
+	IF(NOT LCOV_REMOVE_EXTRA)
+		set(LCOV_REMOVE_EXTRA "")
+	ENDIF() # NOT LCOV_REMOVE_EXTRA
+
 	# Setup target
 	ADD_CUSTOM_TARGET(${_targetname}
 		
@@ -113,7 +117,7 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 		
 		# Capturing lcov counters and generating report
 		COMMAND ${LCOV_PATH} --directory . --capture --output-file ${_outputname}.info
-		COMMAND ${LCOV_PATH} --remove ${_outputname}.info 'tests/*' '/usr/*' --output-file ${_outputname}.info.cleaned
+		COMMAND ${LCOV_PATH} --remove ${_outputname}.info 'tests/*' '/usr/*' ${LCOV_REMOVE_EXTRA} --output-file ${_outputname}.info.cleaned
 		COMMAND ${GENHTML_PATH} -o ${_outputname} ${_outputname}.info.cleaned
 		COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}.info ${_outputname}.info.cleaned
 		

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -102,10 +102,6 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 		MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
 	ENDIF() # NOT GENHTML_PATH
 
-	IF(NOT LCOV_REMOVE_EXTRA)
-		set(LCOV_REMOVE_EXTRA "")
-	ENDIF() # NOT LCOV_REMOVE_EXTRA
-
 	# Setup target
 	ADD_CUSTOM_TARGET(${_targetname}
 		


### PR DESCRIPTION
Add support for variable `LCOV_REMOVE_EXTRA` which can be set before calling `setup_target_for_coverage()` to add additional arguments to `lcov --remove`.

Example usage in CMakeLists.txt:

``` cmake
# remove thirdparty/* sources from lcov report
set(LCOV_REMOVE_EXTRA "'thirdparty/*'")
setup_target_for_coverage(test-${projectName}-coverage test-${projectName} coverage)
```
