### PR TITLE
Fix coverage for UB 16.04

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -131,6 +131,9 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 		MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
 	ENDIF() # NOT GENHTML_PATH
 
+	SET(coverage_info "${CMAKE_BINARY_DIR}/${_outputname}.info")
+	SET(coverage_cleaned "${coverage_info}.cleaned")
+
 	# Setup target
 	ADD_CUSTOM_TARGET(${_targetname}
 
@@ -141,10 +144,10 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 		COMMAND ${_testrunner} ${ARGV3}
 
 		# Capturing lcov counters and generating report
-		COMMAND ${LCOV_PATH} --directory . --capture --output-file ${_outputname}.info
-		COMMAND ${LCOV_PATH} --remove ${_outputname}.info 'tests/*' '/usr/*' --output-file ${_outputname}.info.cleaned
-		COMMAND ${GENHTML_PATH} -o ${_outputname} ${_outputname}.info.cleaned
-		COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}.info ${_outputname}.info.cleaned
+		COMMAND ${LCOV_PATH} --directory . --capture --output-file ${coverage_info}
+		COMMAND ${LCOV_PATH} --remove ${coverage_info} 'tests/*' '/usr/*' --output-file ${coverage_cleaned}
+		COMMAND ${GENHTML_PATH} -o ${_outputname} ${coverage_cleaned}
+		COMMAND ${CMAKE_COMMAND} -E remove ${coverage_info} ${coverage_cleaned}
 
 		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 		COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."


### PR DESCRIPTION
It seems that ubuntu 16.04 has some sort of bug that causes
lcov to change to "/" when running with --remove option.

Work around this by providing absolute path to the output file

Signed-off-by: Yan Burman <yanburman@users.noreply.github.com>