### PR TITLE
Separate argument _testrunner in CodeCoverage.cmake

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -133,6 +133,8 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 
 	SET(coverage_info "${CMAKE_BINARY_DIR}/${_outputname}.info")
 	SET(coverage_cleaned "${coverage_info}.cleaned")
+  
+	SEPARATE_ARGUMENTS(test_command UNIX_COMMAND "${_testrunner}")
 
 	# Setup target
 	ADD_CUSTOM_TARGET(${_targetname}
@@ -141,7 +143,7 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 		${LCOV_PATH} --directory . --zerocounters
 
 		# Run tests
-		COMMAND ${_testrunner} ${ARGV3}
+		COMMAND ${test_command} ${ARGV3}
 
 		# Capturing lcov counters and generating report
 		COMMAND ${LCOV_PATH} --directory . --capture --output-file ${coverage_info}


### PR DESCRIPTION
The unpacking of the _testrunner argument allows to use test runners that cannot be specified as a single command.
MPI applications have to be executed indirectly via mpirun, for example:

`setup_target_for_coverage(coverage "mpirun -n 4 ${TEST_TARGET}" test_coverage)`

The value of `${_testrunner}` is used without change if it is not string or cannot be separated.

The mode `UNIX_COMMAND` is not platform-dependent. It is specified so arguments are separated by spaces instead of semicolons.