### PR TITLE
Add documentation for LCOV_REMOVE_EXTRA

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -146,7 +146,7 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 
 		# Capturing lcov counters and generating report
 		COMMAND ${LCOV_PATH} --directory . --capture --output-file ${coverage_info}
-		COMMAND ${LCOV_PATH} --remove ${coverage_info} 'tests/*' '/usr/*' --output-file ${coverage_cleaned}
+		COMMAND ${LCOV_PATH} --remove ${coverage_info} 'tests/*' '/usr/*' ${LCOV_REMOVE_EXTRA} --output-file ${coverage_cleaned}
 		COMMAND ${GENHTML_PATH} -o ${_outputname} ${coverage_cleaned}
 		COMMAND ${CMAKE_COMMAND} -E remove ${coverage_info} ${coverage_cleaned}
 

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -60,6 +60,12 @@
 #				coverage            # Name of output directory.
 #				)
 #
+#    If you need to exclude additional directories from the report, specify them
+#    using the LCOV_REMOVE_EXTRA variable before calling SETUP_TARGET_FOR_COVERAGE.
+#    For example:
+#
+#    set(LCOV_REMOVE_EXTRA "'thirdparty/*'")
+#
 # 4. Build a Debug build:
 #	 cmake -DCMAKE_BUILD_TYPE=Debug ..
 #	 make


### PR DESCRIPTION
This pull request finishes #5 by adding the requested documentation at the top of `CodeCoverage.cmake`, and also rebases on top of the current master to fix the merge conflicts.