### PR TITLE
Added filename pattern for genhtml and lcov

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -70,8 +70,8 @@ include(CMakeParseArguments)
 
 # Check prereqs
 find_program( GCOV_PATH gcov )
-find_program( LCOV_PATH lcov )
-find_program( GENHTML_PATH genhtml )
+find_program( LCOV_PATH  NAMES lcov lcov.bat lcov.exe lcov.perl)
+find_program( GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat )
 find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
 find_program( SIMPLE_PYTHON_EXECUTABLE python )
 


### PR DESCRIPTION
Gcov is distributed with mingw32 and called 'gcov'. There is no canonical
name for lcov and genhtml on Windows. This patch includes additional
filenames (.bat .perl) to search for find_program() to make the module
work on Windows using genhtml and lcov form [https://github.com/valbok/lcov](https://github.com/valbok/lcov)