### PR TITLE
Improve support for multi project builds

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -223,7 +223,7 @@ function(SETUP_TARGET_FOR_COVERAGE_GCOVR_XML)
 
         # Running gcovr
         COMMAND ${GCOVR_PATH} --xml
-            -r ${CMAKE_SOURCE_DIR} ${GCOVR_EXCLUDES}
+            -r ${PROJECT_SOURCE_DIR} ${GCOVR_EXCLUDES}
             --object-directory=${PROJECT_BINARY_DIR}
             -o ${Coverage_NAME}.xml
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
@@ -280,7 +280,7 @@ function(SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML)
 
         # Running gcovr
         COMMAND ${GCOVR_PATH} --html --html-details
-            -r ${CMAKE_SOURCE_DIR} ${GCOVR_EXCLUDES}
+            -r ${PROJECT_SOURCE_DIR} ${GCOVR_EXCLUDES}
             --object-directory=${PROJECT_BINARY_DIR}
             -o ${Coverage_NAME}/index.html
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}


### PR DESCRIPTION
The module currently does not support testing code coverage when several subdirectories are built from a project/build directory, i.e:

project/
|    build/
|    |    CMakeLists.txt (top-level, builds all subprojects)
|    subproject1/
|    |    CMakeLists.txt
|    |    src/
|    |    lib/
|    other subprojects/

Calling SETUP_TARGET_FOR_COVERAGE_GCOVR_(XML/HTML) within a subproject's CMakeLists.txt and building from the top level points gcovr's root directory to project/build, so the generated coverage report is empty. This PR changes the root directory to point to project/subproject and allows gcovr to generate a correct coverage report for the subproject.