### PR TITLE
Remove unnecessary --coverage flag

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -41,6 +41,8 @@
 # 2017-06-02, Lars Bilke
 # - Merged with modified version from github.com/ufz/ogs
 #
+# 2019-05-06, Anatolii Kurotych
+# - Remove unnecessary --coverage flag
 #
 # USAGE:
 #
@@ -89,7 +91,7 @@ elseif(NOT CMAKE_COMPILER_IS_GNUCXX)
     message(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
 endif()
 
-set(COVERAGE_COMPILER_FLAGS "-g --coverage -fprofile-arcs -ftest-coverage"
+set(COVERAGE_COMPILER_FLAGS "-g -fprofile-arcs -ftest-coverage"
     CACHE INTERNAL "")
 
 set(CMAKE_CXX_FLAGS_COVERAGE
@@ -120,8 +122,6 @@ endif() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     link_libraries(gcov)
-else()
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 endif()
 
 # Defines a target for running and collection code coverage information


### PR DESCRIPTION
Fix warning message for clang.
[--coverage](https://gcc.gnu.org/onlinedocs/gcc-6.2.0/gcc/Instrumentation-Options.html#Instrumentation-Options) is the option is a synonym for -fprofile-arcs -ftest-coverage (when compiling) and -lgcov (when linking). 