### PR TITLE
CodeCoverage: Some enhancements to reporting, tooling

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -44,12 +44,17 @@
 # 2019-05-06, Anatolii Kurotych
 # - Remove unnecessary --coverage flag
 #
-# 2019-12-10, FeRD (Frank Dana)
-# - Set PROJECT_SOURCE_DIR as lcov basedir with -b argument
-# - Add automatic --demangle-cpp if 'c++filt' is available
+# 2019-12-13, FeRD (Frank Dana)
+# - Deprecate COVERAGE_LCOVR_EXCLUDES and COVERAGE_GCOVR_EXCLUDES lists in favor
+#   of tool-agnostic COVERAGE_EXCLUDES variable, or EXCLUDE setup arguments.
+# - CMake 3.4+: All excludes can be specified relative to BASE_DIRECTORY
+# - All setup functions: accept BASE_DIRECTORY, EXCLUDE list
+# - Set lcov basedir with -b argument
+# - Add automatic --demangle-cpp in lcovr, if 'c++filt' is available (can be
+#   overridden with NO_DEMANGLE option in setup_target_for_coverage_lcovr().)
+# - Delete output dir, .info file on 'make clean'
 # - Remove Python detection, since version mismatches will break gcovr
-# - Remove output dir, .info file on 'make clean'
-# - Minor cleanup (lowercase function names, update excludes example...)
+# - Minor cleanup (lowercase function names, update examples...)
 #
 # USAGE:
 #
@@ -64,12 +69,28 @@
 # 3.a (OPTIONAL) Set appropriate optimization flags, e.g. -O0, -O1 or -Og
 #
 # 4. If you need to exclude additional directories from the report, specify them
-#    using full paths in the COVERAGE_LCOV_EXCLUDES variable before calling
-#    setup_target_for_coverage_lcov().
+#    using full paths in the COVERAGE_EXCLUDES variable before calling
+#    setup_target_for_coverage_*().
 #    Example:
-#      set(COVERAGE_LCOV_EXCLUDES
-#          '${PROJECT_SOURCE_DIR}/dir1/*'
-#          '/path/to/my/dir2/*')
+#      set(COVERAGE_EXCLUDES
+#          '${PROJECT_SOURCE_DIR}/src/dir1/*'
+#          '/path/to/my/src/dir2/*')
+#    Or, use the EXCLUDE argument to setup_target_for_coverage_*().
+#    Example:
+#      setup_target_for_coverage_lcov(
+#          NAME coverage
+#          EXECUTABLE testrunner
+#          EXCLUDE "${PROJECT_SOURCE_DIR}/src/dir1/*" "/path/to/my/src/dir2/*")
+# 
+# 4.a NOTE: With CMake 3.4+, COVERAGE_EXCLUDES or EXCLUDE can also be set
+#     relative to the BASE_DIRECTORY (default: PROJECT_SOURCE_DIR)
+#     Example:
+#       set(COVERAGE_EXCLUDES "dir1/*")
+#       setup_target_for_coverage_gcovr_html(
+#           NAME coverage
+#           EXECUTABLE testrunner
+#           BASE_DIRECTORY "${PROJECT_SOURCE_DIR}/src"
+#           EXCLUDE "dir2/*")
 #
 # 5. Use the functions described below to create a custom make target which
 #    runs your test executable and produces a code coverage report.
@@ -145,6 +166,8 @@ endif()
 #     DEPENDENCIES testrunner                     # Dependencies to build first
 #     BASE_DIRECTORY "../"                        # Base directory for report
 #                                                 #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"           # Patterns to exclude (can be relative
+#                                                 #  to BASE_DIRECTORY, with CMake 3.4+)
 #     NO_DEMANGLE                                 # Don't demangle C++ symbols
 #                                                 #  even if c++filt is found
 # )
@@ -152,7 +175,7 @@ function(setup_target_for_coverage_lcov)
 
     set(options NO_DEMANGLE)
     set(oneValueArgs BASE_DIRECTORY NAME)
-    set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS GENHTML_ARGS)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS GENHTML_ARGS)
     cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if(NOT LCOV_PATH)
@@ -169,6 +192,17 @@ function(setup_target_for_coverage_lcov)
     else()
         set(BASEDIR ${PROJECT_SOURCE_DIR})
     endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(LCOV_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_LCOV_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES LCOV_EXCLUDES)
+
     # Conditional arguments
     if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
       set(GENHTML_EXTRA_ARGS "--demangle-cpp")
@@ -189,7 +223,7 @@ function(setup_target_for_coverage_lcov)
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b ${BASEDIR} --capture --output-file ${Coverage_NAME}.info
         # add baseline counters
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file ${Coverage_NAME}.total
-        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${COVERAGE_LCOV_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
 
         # Generate HTML output
         COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
@@ -230,19 +264,22 @@ endfunction() # setup_target_for_coverage_lcov
 #     NAME ctest_coverage                    # New target name
 #     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
 #     DEPENDENCIES executable_target         # Dependencies to build first
+#     BASE_DIRECTORY "../"                   # Base directory for report
+#                                            #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
+#                                            #  to BASE_DIRECTORY, with CMake 3.4+)
 # )
 function(setup_target_for_coverage_gcovr_xml)
 
     set(options NONE)
     set(oneValueArgs BASE_DIRECTORY NAME)
-    set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
     cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if(NOT GCOVR_PATH)
         message(FATAL_ERROR "gcovr not found! Aborting...")
     endif() # NOT GCOVR_PATH
 
-    # Combine excludes to several -e arguments
     # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
     if(${Coverage_BASE_DIRECTORY})
         get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
@@ -250,11 +287,22 @@ function(setup_target_for_coverage_gcovr_xml)
         set(BASEDIR ${PROJECT_SOURCE_DIR})
     endif()
 
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
     set(GCOVR_EXCLUDES "")
-    foreach(EXCLUDE ${COVERAGE_GCOVR_EXCLUDES})
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
+
+    # Combine excludes to several -e arguments
+    set(GCOVR_EXCLUDE_ARGS "")
+    foreach(EXCLUDE ${GCOVR_EXCLUDES})
         string(REPLACE "*" "\\*" EXCLUDE_REPLACED ${EXCLUDE})
-        list(APPEND GCOVR_EXCLUDES "-e")
-        list(APPEND GCOVR_EXCLUDES "${EXCLUDE_REPLACED}")
+        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE_REPLACED}")
     endforeach()
 
     add_custom_target(${Coverage_NAME}
@@ -263,7 +311,7 @@ function(setup_target_for_coverage_gcovr_xml)
 
         # Running gcovr
         COMMAND ${GCOVR_PATH} --xml
-            -r ${BASEDIR} ${GCOVR_EXCLUDES}
+            -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
             --object-directory=${PROJECT_BINARY_DIR}
             -o ${Coverage_NAME}.xml
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
@@ -295,19 +343,20 @@ endfunction() # setup_target_for_coverage_gcovr_xml
 #     DEPENDENCIES executable_target         # Dependencies to build first
 #     BASE_DIRECTORY "../"                   # Base directory for report
 #                                            #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
+#                                            #  to BASE_DIRECTORY, with CMake 3.4+)
 # )
 function(setup_target_for_coverage_gcovr_html)
 
     set(options NONE)
     set(oneValueArgs BASE_DIRECTORY NAME)
-    set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
     cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if(NOT GCOVR_PATH)
         message(FATAL_ERROR "gcovr not found! Aborting...")
     endif() # NOT GCOVR_PATH
 
-    # Combine excludes to several -e arguments
     # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
     if(${Coverage_BASE_DIRECTORY})
         get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
@@ -315,11 +364,22 @@ function(setup_target_for_coverage_gcovr_html)
         set(BASEDIR ${PROJECT_SOURCE_DIR})
     endif()
 
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
     set(GCOVR_EXCLUDES "")
-    foreach(EXCLUDE ${COVERAGE_GCOVR_EXCLUDES})
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
+
+    # Combine excludes to several -e arguments
+    set(GCOVR_EXCLUDE_ARGS "")
+    foreach(EXCLUDE ${GCOVR_EXCLUDES})
         string(REPLACE "*" "\\*" EXCLUDE_REPLACED ${EXCLUDE})
-        list(APPEND GCOVR_EXCLUDES "-e")
-        list(APPEND GCOVR_EXCLUDES "${EXCLUDE_REPLACED}")
+        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE_REPLACED}")
     endforeach()
 
     add_custom_target(${Coverage_NAME}
@@ -331,7 +391,7 @@ function(setup_target_for_coverage_gcovr_html)
 
         # Running gcovr
         COMMAND ${GCOVR_PATH} --html --html-details
-            -r ${BASEDIR} ${GCOVR_EXCLUDES}
+            -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
             --object-directory=${PROJECT_BINARY_DIR}
             -o ${Coverage_NAME}/index.html
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -77,6 +77,7 @@ find_program( GCOV_PATH gcov )
 find_program( LCOV_PATH  NAMES lcov lcov.bat lcov.exe lcov.perl)
 find_program( GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat )
 find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
+find_program( CPPFILT_PATH NAMES c++filt )
 
 if(NOT GCOV_PATH)
     message(FATAL_ERROR "gcov not found! Aborting...")
@@ -148,6 +149,9 @@ function(SETUP_TARGET_FOR_COVERAGE_LCOV)
         message(FATAL_ERROR "genhtml not found! Aborting...")
     endif() # NOT GENHTML_PATH
 
+    # Conditional arguments
+    set(GENHTML_ARGS $<$<BOOL:${CPPFILT_PATH}:>:"--demangle-cpp">)
+
     # Setup target
     add_custom_target(${Coverage_NAME}
 
@@ -164,7 +168,10 @@ function(SETUP_TARGET_FOR_COVERAGE_LCOV)
         # add baseline counters
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file ${Coverage_NAME}.total
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${COVERAGE_LCOV_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
-        COMMAND ${GENHTML_PATH} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+
+        # Generate HTML output
+        COMMAND ${GENHTML_PATH} ${GENHTML_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+
         COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.total ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
 
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -77,7 +77,6 @@ find_program( GCOV_PATH gcov )
 find_program( LCOV_PATH  NAMES lcov lcov.bat lcov.exe lcov.perl)
 find_program( GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat )
 find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
-find_package(Python COMPONENTS Interpreter)
 
 if(NOT GCOV_PATH)
     message(FATAL_ERROR "gcov not found! Aborting...")
@@ -204,10 +203,6 @@ function(SETUP_TARGET_FOR_COVERAGE_GCOVR_XML)
     set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
     cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if(NOT Python_FOUND)
-        message(FATAL_ERROR "python not found! Aborting...")
-    endif()
-
     if(NOT GCOVR_PATH)
         message(FATAL_ERROR "gcovr not found! Aborting...")
     endif() # NOT GCOVR_PATH
@@ -259,10 +254,6 @@ function(SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML)
     set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
     cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if(NOT Python_FOUND)
-        message(FATAL_ERROR "python not found! Aborting...")
-    endif()
-
     if(NOT GCOVR_PATH)
         message(FATAL_ERROR "gcovr not found! Aborting...")
     endif() # NOT GCOVR_PATH
@@ -283,7 +274,7 @@ function(SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML)
         COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/${Coverage_NAME}
 
         # Running gcovr
-        COMMAND ${Python_EXECUTABLE} ${GCOVR_PATH} --html --html-details
+        COMMAND ${GCOVR_PATH} --html --html-details
             -r ${PROJECT_SOURCE_DIR} ${GCOVR_EXCLUDES}
             --object-directory=${PROJECT_BINARY_DIR}
             -o ${Coverage_NAME}/index.html

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -44,6 +44,13 @@
 # 2019-05-06, Anatolii Kurotych
 # - Remove unnecessary --coverage flag
 #
+# 2019-12-10, FeRD (Frank Dana)
+# - Set PROJECT_SOURCE_DIR as lcov basedir with -b argument
+# - Add automatic --demangle-cpp if 'c++filt' is available
+# - Remove Python detection, since version mismatches will break gcovr
+# - Remove output dir, .info file on 'make clean'
+# - Minor cleanup (lowercase function names, update excludes example...)
+#
 # USAGE:
 #
 # 1. Copy this file into your cmake modules path.
@@ -52,7 +59,7 @@
 #      include(CodeCoverage)
 #
 # 3. Append necessary compiler flags:
-#      APPEND_COVERAGE_COMPILER_FLAGS()
+#      append_coverage_compiler_flags()
 #
 # 3.a (OPTIONAL) Set appropriate optimization flags, e.g. -O0, -O1 or -Og
 #
@@ -129,12 +136,12 @@ endif()
 # NOTE! The executable should always have a ZERO as exit code otherwise
 # the coverage generation will not complete.
 #
-# SETUP_TARGET_FOR_COVERAGE_LCOV(
+# setup_target_for_coverage_lcov(
 #     NAME testrunner_coverage                    # New target name
 #     EXECUTABLE testrunner -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
 #     DEPENDENCIES testrunner                     # Dependencies to build first
 # )
-function(SETUP_TARGET_FOR_COVERAGE_LCOV)
+function(setup_target_for_coverage_lcov)
 
     set(options NONE)
     set(oneValueArgs NAME)
@@ -199,19 +206,19 @@ function(SETUP_TARGET_FOR_COVERAGE_LCOV)
         ADDITIONAL_MAKE_CLEAN_FILES
         ${Coverage_NAME})
 
-endfunction() # SETUP_TARGET_FOR_COVERAGE_LCOV
+endfunction() # setup_target_for_coverage_lcov
 
 # Defines a target for running and collection code coverage information
 # Builds dependencies, runs the given executable and outputs reports.
 # NOTE! The executable should always have a ZERO as exit code otherwise
 # the coverage generation will not complete.
 #
-# SETUP_TARGET_FOR_COVERAGE_GCOVR_XML(
+# setup_target_for_coverage_gcovr_xml(
 #     NAME ctest_coverage                    # New target name
 #     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
 #     DEPENDENCIES executable_target         # Dependencies to build first
 # )
-function(SETUP_TARGET_FOR_COVERAGE_GCOVR_XML)
+function(setup_target_for_coverage_gcovr_xml)
 
     set(options NONE)
     set(oneValueArgs NAME)
@@ -255,19 +262,19 @@ function(SETUP_TARGET_FOR_COVERAGE_GCOVR_XML)
         ADDITIONAL_MAKE_CLEAN_FILES
         ${Coverage_NAME})
 
-endfunction() # SETUP_TARGET_FOR_COVERAGE_GCOVR_XML
+endfunction() # setup_target_for_coverage_gcovr_xml
 
 # Defines a target for running and collection code coverage information
 # Builds dependencies, runs the given executable and outputs reports.
 # NOTE! The executable should always have a ZERO as exit code otherwise
 # the coverage generation will not complete.
 #
-# SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML(
+# setup_target_for_coverage_gcovr_html(
 #     NAME ctest_coverage                    # New target name
 #     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
 #     DEPENDENCIES executable_target         # Dependencies to build first
 # )
-function(SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML)
+function(setup_target_for_coverage_gcovr_html)
 
     set(options NONE)
     set(oneValueArgs NAME)
@@ -314,10 +321,10 @@ function(SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML)
         ADDITIONAL_MAKE_CLEAN_FILES
         ${Coverage_NAME})
 
-endfunction() # SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML
+endfunction() # setup_target_for_coverage_gcovr_html
 
-function(APPEND_COVERAGE_COMPILER_FLAGS)
+function(append_coverage_compiler_flags)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
     message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
-endfunction() # APPEND_COVERAGE_COMPILER_FLAGS
+endfunction() # append_coverage_compiler_flags

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -173,6 +173,7 @@ function(SETUP_TARGET_FOR_COVERAGE_LCOV)
         COMMAND ${GENHTML_PATH} ${GENHTML_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
 
         COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.total ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+        BYPRODUCTS ${Coverage_NAME}.info
 
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${Coverage_DEPENDENCIES}
@@ -190,6 +191,11 @@ function(SETUP_TARGET_FOR_COVERAGE_LCOV)
         COMMAND ;
         COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
     )
+
+    # Clean up output on 'make clean'
+    set_property(DIRECTORY APPEND PROPERTY
+        ADDITIONAL_MAKE_CLEAN_FILES
+        ${Coverage_NAME})
 
 endfunction() # SETUP_TARGET_FOR_COVERAGE_LCOV
 
@@ -241,6 +247,11 @@ function(SETUP_TARGET_FOR_COVERAGE_GCOVR_XML)
         COMMAND ;
         COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
     )
+
+    # Clean up output on 'make clean'
+    set_property(DIRECTORY APPEND PROPERTY
+        ADDITIONAL_MAKE_CLEAN_FILES
+        ${Coverage_NAME})
 
 endfunction() # SETUP_TARGET_FOR_COVERAGE_GCOVR_XML
 
@@ -295,6 +306,11 @@ function(SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML)
         COMMAND ;
         COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
     )
+
+    # Clean up output on 'make clean'
+    set_property(DIRECTORY APPEND PROPERTY
+        ADDITIONAL_MAKE_CLEAN_FILES
+        ${Coverage_NAME})
 
 endfunction() # SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML
 

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -150,7 +150,9 @@ function(SETUP_TARGET_FOR_COVERAGE_LCOV)
     endif() # NOT GENHTML_PATH
 
     # Conditional arguments
-    set(GENHTML_ARGS $<$<BOOL:${CPPFILT_PATH}:>:"--demangle-cpp">)
+    if(CPPFILT_PATH)
+      set(GENHTML_EXTRA_ARGS "--demangle-cpp")
+    endif()
 
     # Setup target
     add_custom_target(${Coverage_NAME}
@@ -170,7 +172,7 @@ function(SETUP_TARGET_FOR_COVERAGE_LCOV)
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${COVERAGE_LCOV_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
 
         # Generate HTML output
-        COMMAND ${GENHTML_PATH} ${GENHTML_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+        COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
 
         COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.total ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
         BYPRODUCTS ${Coverage_NAME}.info

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -145,10 +145,12 @@ endif()
 #     DEPENDENCIES testrunner                     # Dependencies to build first
 #     BASE_DIRECTORY "../"                        # Base directory for report
 #                                                 #  (defaults to PROJECT_SOURCE_DIR)
+#     NO_DEMANGLE                                 # Don't demangle C++ symbols
+#                                                 #  even if c++filt is found
 # )
 function(setup_target_for_coverage_lcov)
 
-    set(options NONE)
+    set(options NO_DEMANGLE)
     set(oneValueArgs BASE_DIRECTORY NAME)
     set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS GENHTML_ARGS)
     cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -168,7 +170,7 @@ function(setup_target_for_coverage_lcov)
         set(BASEDIR ${PROJECT_SOURCE_DIR})
     endif()
     # Conditional arguments
-    if(CPPFILT_PATH)
+    if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
       set(GENHTML_EXTRA_ARGS "--demangle-cpp")
     endif()
 

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -64,9 +64,12 @@
 # 3.a (OPTIONAL) Set appropriate optimization flags, e.g. -O0, -O1 or -Og
 #
 # 4. If you need to exclude additional directories from the report, specify them
-#    using the COVERAGE_LCOV_EXCLUDES variable before calling SETUP_TARGET_FOR_COVERAGE_LCOV.
+#    using full paths in the COVERAGE_LCOV_EXCLUDES variable before calling
+#    setup_target_for_coverage_lcov().
 #    Example:
-#      set(COVERAGE_LCOV_EXCLUDES 'dir1/*' 'dir2/*')
+#      set(COVERAGE_LCOV_EXCLUDES
+#          '${PROJECT_SOURCE_DIR}/dir1/*'
+#          '/path/to/my/dir2/*')
 #
 # 5. Use the functions described below to create a custom make target which
 #    runs your test executable and produces a code coverage report.

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -156,15 +156,15 @@ function(SETUP_TARGET_FOR_COVERAGE_LCOV)
     add_custom_target(${Coverage_NAME}
 
         # Cleanup lcov
-        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -directory . --zerocounters
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -directory . -b ${PROJECT_SOURCE_DIR} --zerocounters
         # Create baseline to make sure untouched files show up in the report
-        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -o ${Coverage_NAME}.base
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -b ${PROJECT_SOURCE_DIR} -o ${Coverage_NAME}.base
 
         # Run tests
         COMMAND ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
 
         # Capturing lcov counters and generating report
-        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . --capture --output-file ${Coverage_NAME}.info
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b ${PROJECT_SOURCE_DIR} --capture --output-file ${Coverage_NAME}.info
         # add baseline counters
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file ${Coverage_NAME}.total
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${COVERAGE_LCOV_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned


### PR DESCRIPTION
This adds a few enhancements to `CodeCoverage.cmake` that address issues I hit while integrating it into our build tree. Specifically:

* Remove the Python detection completely, since it can sabotage the run if the Python version chosen by CMake isn't the correct one for `gcovr`.
* Add a `BASE_DIRECTORY` argument to all `setup_*()` functions, which sets the base dir of the report.
    - Previously gcovr always used `PROJECT_SOURCE_DIR`, and lcov wasn't setting the basedir at all. Now all three will default to `PROJECT_SOURCE_DIR`, but can be overridden.
    - Setting the lcov basedir allows the `--no-external` option to work properly if passed in via `LCOV_ARGS`.
* Add automatic addition of `--demangle-cpp` to the `genhtml` command line, iff a `c++filt` executable is found on the system.
    - This can be overridden by passing `NO_DEMANGLE` to `setup_target_for_coverage_lcov()`.
* Major enhancements to exclude processing:
    - The `COVERAGE_LCOV_EXCLUDES` and `COVERAGE_GCOVR_EXCLUDES` variables are now deprecated in favor of `COVERAGE_EXCLUDES`, which will be used by both.
    - All `setup_*()` functions also now take a multi-value argument, `EXCLUDE`, to specify exclude patterns instead of using the `COVERAGE_EXCLUDES` variable.
    - **CMake 3.4+ only**: Exclude patterns (specified via any means) can now be relative to the `BASE_DIRECTORY`, instead of having to be absolute paths. (This requires a version of CMake where `get_filename_component()` accepts the `BASE_DIR` argument.)
* Add CMake configuration to clean up the `.info` file and the report output directory on '`make clean`'.

That last one makes me feel a bit better about the tool's housekeeping. Though TBH, I'd really love to be able to set the `gcov` output files as `GENERATED` so that CMake will clean _those_ up as well. I just can't seem to find a reasonable way to do that, without resorting to ugly globbing or the like.