### PR TITLE
Added gfortran support

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -168,12 +168,8 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
 endif() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
 
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     link_libraries(gcov)
-else()
-    if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-        link_libraries(gcov)
-    endif()
 endif()
 
 # Defines a target for running and collection code coverage information

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -59,6 +59,9 @@
 # 2019-12-19, FeRD (Frank Dana)
 # - Rename Lcov outputs, make filtered file canonical, fix cleanup for targets
 #
+# 2020-01-19, Bob Apthorpe
+# - Added gfortran support
+#
 # USAGE:
 #
 # 1. Copy this file into your cmake modules path.
@@ -122,12 +125,22 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
         message(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
     endif()
 elseif(NOT CMAKE_COMPILER_IS_GNUCXX)
-    message(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+    if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "[Ff]lang")
+        # Do nothing; exit conditional without error if true
+    elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
+        # Do nothing; exit conditional without error if true
+    else()
+        message(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+    endif()
 endif()
 
 set(COVERAGE_COMPILER_FLAGS "-g -fprofile-arcs -ftest-coverage"
     CACHE INTERNAL "")
 
+set(CMAKE_Fortran_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
+    CACHE STRING "Flags used by the Fortran compiler during coverage builds."
+    FORCE )
 set(CMAKE_CXX_FLAGS_COVERAGE
     ${COVERAGE_COMPILER_FLAGS}
     CACHE STRING "Flags used by the C++ compiler during coverage builds."
@@ -145,6 +158,7 @@ set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
     CACHE STRING "Flags used by the shared libraries linker during coverage builds."
     FORCE )
 mark_as_advanced(
+    CMAKE_Fortran_FLAGS_COVERAGE
     CMAKE_CXX_FLAGS_COVERAGE
     CMAKE_C_FLAGS_COVERAGE
     CMAKE_EXE_LINKER_FLAGS_COVERAGE
@@ -156,6 +170,10 @@ endif() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     link_libraries(gcov)
+else()
+    if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+        link_libraries(gcov)
+    endif()
 endif()
 
 # Defines a target for running and collection code coverage information
@@ -411,5 +429,6 @@ endfunction() # setup_target_for_coverage_gcovr_html
 function(append_coverage_compiler_flags)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
     message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
 endfunction() # append_coverage_compiler_flags


### PR DESCRIPTION
I've added minimal support for gfortran. The original code was failing on undefined/incompatible C/C++ compiler so I added a workaround check for gfortran at the point the original was failing. This might break if you have a mixed-language project and you're using an incompatible C/C++ compiler but (for some reason) you're using gfortran. That seems unlikely but regardless, the logic should checked over and you may want to replace it with something more robust.

Beyond that, I followed the pattern established for setting options for C and C++ compilers.

I've tested this locally with CMake 3.14.4, gfortran & gcov 9.2.1, and HEAD of lcov (GCC 9.x format output from gcov is only supported in the bleeding-edge release of lcov)

This is more of a minimal proof-of-concept than thoroughly tested production code; I don't believe there are any major faults but it definitely needs review and additional testing.

FWIW, seeing coverage stats for legacy Fortran code running sample cases is incredibly helpful. It's amazing how spoiled you feel using a language with test facilities... 