### PR TITLE
CodeCoverage.cmake: Fix directory exclusion

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -216,7 +216,7 @@ function(setup_target_for_coverage_lcov)
         if(CMAKE_VERSION VERSION_GREATER 3.4)
             get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
         endif()
-        list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
+        list(APPEND LCOV_EXCLUDES '${EXCLUDE}')
     endforeach()
     list(REMOVE_DUPLICATES LCOV_EXCLUDES)
 


### PR DESCRIPTION
This change fixes an incorrect directory exception in the code coverage CMake module. An `EXCLUDE` parameter of the `setup_target_for_coverage_lcov()` function didn't work. The folders were not excluded. The reason is that `gcov` requires to wrap each excludes in quotes, but CMake removes double-quotes. Therefore the solution is to use single-quotes.