### PR TITLE
CodeCoverage: Use VERBATIM for target commands

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -256,6 +256,7 @@ function(setup_target_for_coverage_lcov)
 
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
         COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
     )
 
@@ -335,6 +336,7 @@ function(setup_target_for_coverage_gcovr_xml)
         BYPRODUCTS ${Coverage_NAME}.xml
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
         COMMENT "Running gcovr to produce Cobertura code coverage report."
     )
 
@@ -411,6 +413,7 @@ function(setup_target_for_coverage_gcovr_html)
         BYPRODUCTS ${PROJECT_BINARY_DIR}/${Coverage_NAME}  # report directory
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
         COMMENT "Running gcovr to produce HTML code coverage report."
     )
 

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -62,6 +62,10 @@
 # 2020-01-19, Bob Apthorpe
 # - Added gfortran support
 #
+# 2020-02-17, FeRD (Frank Dana)
+# - Make all add_custom_target()s VERBATIM to auto-escape wildcard characters
+#   in EXCLUDEs, and remove manual escaping from gcovr targets
+#
 # USAGE:
 #
 # 1. Copy this file into your cmake modules path.
@@ -319,9 +323,8 @@ function(setup_target_for_coverage_gcovr_xml)
     # Combine excludes to several -e arguments
     set(GCOVR_EXCLUDE_ARGS "")
     foreach(EXCLUDE ${GCOVR_EXCLUDES})
-        string(REPLACE "*" "\\*" EXCLUDE_REPLACED ${EXCLUDE})
         list(APPEND GCOVR_EXCLUDE_ARGS "-e")
-        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE_REPLACED}")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
     endforeach()
 
     add_custom_target(${Coverage_NAME}
@@ -392,9 +395,8 @@ function(setup_target_for_coverage_gcovr_html)
     # Combine excludes to several -e arguments
     set(GCOVR_EXCLUDE_ARGS "")
     foreach(EXCLUDE ${GCOVR_EXCLUDES})
-        string(REPLACE "*" "\\*" EXCLUDE_REPLACED ${EXCLUDE})
         list(APPEND GCOVR_EXCLUDE_ARGS "-e")
-        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE_REPLACED}")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
     endforeach()
 
     add_custom_target(${Coverage_NAME}


### PR DESCRIPTION
@lieser raised a remaining issue in #28 with the coverage excludes, specifically that special characters (wildcards) aren't making it to the coverage commands because they're not properly quoted/escaped.

This PR adds `VERBATIM` to the`add_custom_target()` call for all three coverage modes, ensuring that CMake will protect all of the arguments on the `COMMAND` lines used to execute the tools.

Fixes: #28