### PR TITLE
Code coverage verbose mode and way to add additional gcovr arguments

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -292,7 +292,7 @@ function(setup_target_for_coverage_lcov)
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
         # filter collected data to final coverage report
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
-        
+ 
         # Generate HTML output
         COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${Coverage_NAME}.info
 

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -445,6 +445,28 @@ function(setup_target_for_coverage_gcovr_html)
         list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
     endforeach()
 
+    if(CODE_COVERAGE_VERBOSE)
+        message(STATUS
+            "Executed command report (lists are shown semicolon "
+            "separated here but are escaped again): "
+        )
+
+        message(STATUS "Command to run tests: ")
+        message(STATUS "${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}")
+
+        message(STATUS "Command to create folder: ")
+        message(STATUS "${CMAKE_COMMAND} -E make_directory "
+            "${PROJECT_BINARY_DIR}/${Coverage_NAME}"
+        )
+
+        message(STATUS "GCOVR command: ")
+        message(STATUS "${GCOVR_PATH} --html --html-details "
+            "-r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS} "
+            "--object-directory=${PROJECT_BINARY_DIR} "
+            "-o ${Coverage_NAME}/index.html "
+        )
+    endif()
+
     add_custom_target(${Coverage_NAME}
         # Run tests
         ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -427,6 +427,8 @@ endfunction() # setup_target_for_coverage_gcovr_xml
 #     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
 #                                            #  to BASE_DIRECTORY, with CMake 3.4+)
 # )
+# The user can set the variable GCOVR_ADDITIONAL_ARGS to supply additional flags to the 
+# GCVOR command.
 function(setup_target_for_coverage_gcovr_html)
 
     set(options NONE)

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -226,7 +226,7 @@ function(setup_target_for_coverage_lcov)
         list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
     endforeach()
     list(REMOVE_DUPLICATES LCOV_EXCLUDES)
-    
+
     # Conditional arguments
     if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
       set(GENHTML_EXTRA_ARGS "--demangle-cpp")
@@ -242,21 +242,21 @@ function(setup_target_for_coverage_lcov)
             "--gcov-tool ${GCOV_PATH} -directory . -b ${BASEDIR} "
             "--zerocounters"
         )
-        
+
         message(STATUS "Command to create baseline: ")
         message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
             "${GCOV_PATH} -c -i -d . -b ${BASEDIR} -o ${Coverage_NAME}.base"
         )
-        
+
         message(STATUS "Command to run the tests: ")
         message(STATUS "${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}")
-        
+
         message(STATUS "Command to capture counters and generate report: ")
         message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
             "${GCOV_PATH} --directory . -b ${BASEDIR} --capture "
             "--output-file ${Coverage_NAME}.capture"
         )
-        
+
         message(STATUS "Command to add baseline counters: ")
         message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
             "${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture "
@@ -268,7 +268,7 @@ function(setup_target_for_coverage_lcov)
             "${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} "
             "--output-file ${Coverage_NAME}.info"
         )
-        
+
         message(STATUS "Command to generate HTML output: ")
         message(STATUS "${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} "
             "${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${Coverage_NAME}.info"

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -292,6 +292,7 @@ function(setup_target_for_coverage_lcov)
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
         # filter collected data to final coverage report
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
+        
         # Generate HTML output
         COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${Coverage_NAME}.info
 

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -231,10 +231,10 @@ function(setup_target_for_coverage_lcov)
     if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
       set(GENHTML_EXTRA_ARGS "--demangle-cpp")
     endif()
-    
+
     if(CODE_COVERAGE_VERBOSE)
-        message(STATUS 
-            "Executed command report (lists are shown semicolon " 
+        message(STATUS
+            "Executed command report (lists are shown semicolon "
             "separated here but are escaped again): "
         )
         message(STATUS "Command to clean up LCOV: ")

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -233,46 +233,46 @@ function(setup_target_for_coverage_lcov)
     endif()
     
     if(CODE_COVERAGE_VERBOSE)
-    	message(STATUS 
-    		"Executed command report (lists are shown semicolon " 
-    		"separated here but are escaped again): "
-    	)
-    	message(STATUS "Command to clean up LCOV: ")
-    	message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} "
-    		"--gcov-tool ${GCOV_PATH} -directory . -b ${BASEDIR} "
-    		"--zerocounters"
-    	)
-    	
-    	message(STATUS "Command to create baseline: ")
-    	message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
-    		"${GCOV_PATH} -c -i -d . -b ${BASEDIR} -o ${Coverage_NAME}.base"
-    	)
-    	
-    	message(STATUS "Command to run the tests: ")
-    	message(STATUS "${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}")
-    	
-    	message(STATUS "Command to capture counters and generate report: ")
-    	message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
-    		"${GCOV_PATH} --directory . -b ${BASEDIR} --capture "
-    		"--output-file ${Coverage_NAME}.capture"
-    	)
-    	
-    	message(STATUS "Command to add baseline counters: ")
-    	message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
-    		"${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture "
-    		"--output-file ${Coverage_NAME}.total"
-    	)
+        message(STATUS 
+            "Executed command report (lists are shown semicolon " 
+            "separated here but are escaped again): "
+        )
+        message(STATUS "Command to clean up LCOV: ")
+        message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} "
+            "--gcov-tool ${GCOV_PATH} -directory . -b ${BASEDIR} "
+            "--zerocounters"
+        )
+        
+        message(STATUS "Command to create baseline: ")
+        message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
+            "${GCOV_PATH} -c -i -d . -b ${BASEDIR} -o ${Coverage_NAME}.base"
+        )
+        
+        message(STATUS "Command to run the tests: ")
+        message(STATUS "${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}")
+        
+        message(STATUS "Command to capture counters and generate report: ")
+        message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
+            "${GCOV_PATH} --directory . -b ${BASEDIR} --capture "
+            "--output-file ${Coverage_NAME}.capture"
+        )
+        
+        message(STATUS "Command to add baseline counters: ")
+        message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
+            "${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture "
+            "--output-file ${Coverage_NAME}.total"
+        )
 
-    	message(STATUS "Command to filter collected data: ")
-    	message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
-    		"${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} "
-    		"--output-file ${Coverage_NAME}.info"
-    	)
-    	
-    	message(STATUS "Command to generate HTML output: ")
-    	message(STATUS "${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} "
-    		"${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${Coverage_NAME}.info"
-    	)
+        message(STATUS "Command to filter collected data: ")
+        message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
+            "${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} "
+            "--output-file ${Coverage_NAME}.info"
+        )
+        
+        message(STATUS "Command to generate HTML output: ")
+        message(STATUS "${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} "
+            "${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${Coverage_NAME}.info"
+        )
     endif()
 
     # Setup target

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -461,7 +461,7 @@ function(setup_target_for_coverage_gcovr_html)
 
         message(STATUS "GCOVR command: ")
         message(STATUS "${GCOVR_PATH} --html --html-details "
-            "-r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS} "
+            "-r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS} ${GCOVR_EXCLUDE_ARGS} "
             "--object-directory=${PROJECT_BINARY_DIR} "
             "-o ${Coverage_NAME}/index.html "
         )
@@ -476,7 +476,7 @@ function(setup_target_for_coverage_gcovr_html)
 
         # Running gcovr
         COMMAND ${GCOVR_PATH} --html --html-details
-            -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
+            -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS} ${GCOVR_EXCLUDE_ARGS}
             --object-directory=${PROJECT_BINARY_DIR}
             -o ${Coverage_NAME}/index.html
 

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -68,6 +68,8 @@
 #
 # 2021-01-19, Robin Mueller
 # - Add CODE_COVERAGE_VERBOSE option which will allow to print out commands which are run
+# - Added the option for users to set the GCOVR_ADDITIONAL_ARGS variable to supply additional
+#   flags to the gcovr command
 #
 # USAGE:
 #
@@ -355,6 +357,8 @@ endfunction() # setup_target_for_coverage_lcov
 #     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
 #                                            #  to BASE_DIRECTORY, with CMake 3.4+)
 # )
+# The user can set the variable GCOVR_ADDITIONAL_ARGS to supply additional flags to the
+# GCVOR command.
 function(setup_target_for_coverage_gcovr_xml)
 
     set(options NONE)
@@ -450,7 +454,7 @@ endfunction() # setup_target_for_coverage_gcovr_xml
 #     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
 #                                            #  to BASE_DIRECTORY, with CMake 3.4+)
 # )
-# The user can set the variable GCOVR_ADDITIONAL_ARGS to supply additional flags to the 
+# The user can set the variable GCOVR_ADDITIONAL_ARGS to supply additional flags to the
 # GCVOR command.
 function(setup_target_for_coverage_gcovr_html)
 

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -223,10 +223,10 @@ function(setup_target_for_coverage_lcov)
         if(CMAKE_VERSION VERSION_GREATER 3.4)
             get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
         endif()
-        list(APPEND LCOV_EXCLUDES "\"${EXCLUDE}\"")
+        list(APPEND LCOV_EXCLUDES "'${EXCLUDE}'")
     endforeach()
     list(REMOVE_DUPLICATES LCOV_EXCLUDES)
-    message(STATUS "${LCOV_EXCLUDES}")
+    string(REPLACE ";" " " LCOV_EXCLUDES "${LCOV_EXCLUDES}")
 
     # Conditional arguments
     if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -418,14 +418,9 @@ function(setup_target_for_coverage_gcovr_xml)
     endif()
 
     add_custom_target(${Coverage_NAME}
-        # Run tests
-        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
-
-        # Running gcovr
-        COMMAND ${GCOVR_PATH} --xml
-            -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
-            --object-directory=${PROJECT_BINARY_DIR}
-            -o ${Coverage_NAME}.xml
+        COMMAND ${GCOVR_XML_EXEC_TESTS_CMD}
+        COMMAND ${GCOVR_XML_CMD}
+        
         BYPRODUCTS ${Coverage_NAME}.xml
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${Coverage_DEPENDENCIES}

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -292,7 +292,7 @@ function(setup_target_for_coverage_lcov)
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
         # filter collected data to final coverage report
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
- 
+
         # Generate HTML output
         COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${Coverage_NAME}.info
 

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -238,43 +238,43 @@ function(setup_target_for_coverage_lcov)
     # Setting up commands which will be run to generate coverage data.
     # Cleanup lcov
     set(LCOV_CLEAN_CMD 
-    		${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -directory . 
-    		-b ${BASEDIR} --zerocounters
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -directory . 
+        -b ${BASEDIR} --zerocounters
     )
     # Create baseline to make sure untouched files show up in the report
     set(LCOV_BASELINE_CMD 
-            ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -b 
-            ${BASEDIR} -o ${Coverage_NAME}.base
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -b 
+        ${BASEDIR} -o ${Coverage_NAME}.base
     )
     # Run tests
     set(LCOV_EXEC_TESTS_CMD 
-            ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
     )    
     # Capturing lcov counters and generating report
     set(LCOV_CAPTURE_CMD 
-            ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b 
-            ${BASEDIR} --capture --output-file ${Coverage_NAME}.capture
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b 
+        ${BASEDIR} --capture --output-file ${Coverage_NAME}.capture
     )
     # add baseline counters
     set(LCOV_BASELINE_COUNT_CMD
-            ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base 
-            -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base 
+        -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
     ) 
     # filter collected data to final coverage report
     set(LCOV_FILTER_CMD 
-            ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove 
-            ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove 
+        ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
     )    
     # Generate HTML output
     set(LCOV_GEN_HTML_CMD
-            ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o 
-            ${Coverage_NAME} ${Coverage_NAME}.info
+        ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o 
+        ${Coverage_NAME} ${Coverage_NAME}.info
     )
     
 
     if(CODE_COVERAGE_VERBOSE)
         message(STATUS "Executed command report")
-        message(STATUS "Command to clean up LCOV: ")
+        message(STATUS "Command to clean up lcov: ")
         string(REPLACE ";" " " LCOV_CLEAN_CMD_SPACED "${LCOV_CLEAN_CMD}")
         message(STATUS "${LCOV_CLEAN_CMD_SPACED}")
 
@@ -298,7 +298,7 @@ function(setup_target_for_coverage_lcov)
         string(REPLACE ";" " " LCOV_FILTER_CMD_SPACED "${LCOV_FILTER_CMD}")
         message(STATUS "${LCOV_FILTER_CMD_SPACED}")
 
-        message(STATUS "Command to generate HTML output: ")
+        message(STATUS "Command to generate lcov HTML output: ")
         string(REPLACE ";" " " LCOV_GEN_HTML_CMD_SPACED "${LCOV_GEN_HTML_CMD}")
         message(STATUS "${LCOV_GEN_HTML_CMD_SPACED}")
     endif()
@@ -389,6 +389,29 @@ function(setup_target_for_coverage_gcovr_xml)
         list(APPEND GCOVR_EXCLUDE_ARGS "-e")
         list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
     endforeach()
+    
+    # Set up commands which will be run to generate coverage data
+    # Run tests
+    set(GCOVR_XML_EXEC_TESTS_CMD
+        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+    )
+    # Running gcovr
+    set(GCOVR_XML_CMD
+        ${GCOVR_PATH} --xml -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS} ${GCOVR_EXCLUDE_ARGS} 
+        --object-directory=${PROJECT_BINARY_DIR} -o ${Coverage_NAME}.xml
+    )
+    
+    if(CODE_COVERAGE_VERBOSE)
+        message(STATUS "Executed command report")
+
+        message(STATUS "Command to run tests: ")
+        string(REPLACE ";" " " GCOVR_XML_EXEC_TESTS_CMD_SPACED "${GCOVR_XML_EXEC_TESTS_CMD}")
+        message(STATUS "${GCOVR_XML_EXEC_TESTS_CMD_SPACED}")
+
+        message(STATUS "Command to generate gcovr XML coverage data: ")
+        string(REPLACE ";" " " GCOVR_XML_CMD_SPACED "${GCOVR_XML_CMD}")
+        message(STATUS "${GCOVR_XML_CMD_SPACED}")
+    endif()
 
     add_custom_target(${Coverage_NAME}
         # Run tests
@@ -467,23 +490,21 @@ function(setup_target_for_coverage_gcovr_html)
     # Set up commands which will be run to generate coverage data
     # Run tests
     set(GCOVR_HTML_EXEC_TESTS_CMD
-            ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
     )
     # Create folder
     set(GCOVR_HTML_FOLDER_CMD
-            ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/${Coverage_NAME}
+        ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/${Coverage_NAME}
     )
     # Running gcovr
     set(GCOVR_HTML_CMD
-            ${GCOVR_PATH} --html --html-details -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS}
-            ${GCOVR_EXCLUDE_ARGS} --object-directory=${PROJECT_BINARY_DIR}
-            -o ${Coverage_NAME}/index.html
+        ${GCOVR_PATH} --html --html-details -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS}
+        ${GCOVR_EXCLUDE_ARGS} --object-directory=${PROJECT_BINARY_DIR} 
+        -o ${Coverage_NAME}/index.html
     )
 
     if(CODE_COVERAGE_VERBOSE)
-        message(STATUS
-            "Executed command report"
-        )
+        message(STATUS "Executed command report")
 
         message(STATUS "Command to run tests: ")
         string(REPLACE ";" " " GCOVR_HTML_EXEC_TESTS_CMD_SPACED "${GCOVR_HTML_EXEC_TESTS_CMD}")
@@ -493,7 +514,7 @@ function(setup_target_for_coverage_gcovr_html)
         string(REPLACE ";" " " GCOVR_HTML_FOLDER_CMD_SPACED "${GCOVR_HTML_FOLDER_CMD}")
         message(STATUS "${GCOVR_HTML_FOLDER_CMD_SPACED}")
 
-        message(STATUS "Command to generate GCOVR coverage data: ")
+        message(STATUS "Command to generate gcovr HTML coverage data: ")
         string(REPLACE ";" " " GCOVR_HTML_CMD_SPACED "${GCOVR_HTML_CMD}")
         message(STATUS "${GCOVR_HTML_CMD_SPACED}")
     endif()

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -223,17 +223,20 @@ function(setup_target_for_coverage_lcov)
         if(CMAKE_VERSION VERSION_GREATER 3.4)
             get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
         endif()
-        list(APPEND LCOV_EXCLUDES "'${EXCLUDE}'")
+        list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
     endforeach()
     list(REMOVE_DUPLICATES LCOV_EXCLUDES)
-    string(REPLACE ";" " " LCOV_EXCLUDES "${LCOV_EXCLUDES}")
-
+    
     # Conditional arguments
     if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
       set(GENHTML_EXTRA_ARGS "--demangle-cpp")
     endif()
     
     if(CODE_COVERAGE_VERBOSE)
+    	message(STATUS 
+    		"Executed command report (lists are shown semicolon " 
+    		"separated here but are escaped again): "
+    	)
     	message(STATUS "Command to clean up LCOV: ")
     	message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} "
     		"--gcov-tool ${GCOV_PATH} -directory . -b ${BASEDIR} "
@@ -255,15 +258,15 @@ function(setup_target_for_coverage_lcov)
     	)
     	
     	message(STATUS "Command to add baseline counters: ")
-    	message(STATUS "${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a  "
-    		"${Coverage_NAME}.base -a ${Coverage_NAME}.capture --output-file "
-    		"${Coverage_NAME}.total"
+    	message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
+    		"${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture "
+    		"--output-file ${Coverage_NAME}.total"
     	)
-    	
+
     	message(STATUS "Command to filter collected data: ")
-    	message(STATUS "${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} "
-    		"--remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file "
-    		"${Coverage_NAME}.info"
+    	message(STATUS "${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool "
+    		"${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} "
+    		"--output-file ${Coverage_NAME}.info"
     	)
     	
     	message(STATUS "Command to generate HTML output: ")
@@ -289,7 +292,6 @@ function(setup_target_for_coverage_lcov)
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
         # filter collected data to final coverage report
         COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
-
         # Generate HTML output
         COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${Coverage_NAME}.info
 


### PR DESCRIPTION
I added an additional CODE_COVERAGE_VERBOSE option to add additional output to the CMake configuration. This includes printing all the run LCOV commands so they can be verified if there are issues.