### PR TITLE
Remove second exclude call

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -638,7 +638,6 @@ function(setup_target_for_coverage_fastcov)
         --process-gcno
         --output ${Coverage_NAME}.json
         --exclude ${FASTCOV_EXCLUDES}
-        --exclude ${FASTCOV_EXCLUDES}
     )
     
     set(FASTCOV_CONVERT_CMD ${FASTCOV_PATH}


### PR DESCRIPTION
The double usage of `--exclude` appears to be a typo, and causes
```text
CMake Error at CMakeModules/CodeCoverage.cmake:689 (add_custom_target):
  add_custom_target Wrong syntax.  Unknown type of argument.
Call Stack (most recent call first):
  build.cmake:87 (setup_target_for_coverage_fastcov)
  CMakeLists.txt:146 (include)
```
when I try to use it