### PR TITLE
fix(CodeCoverage): follow `CMake` policy CMP0175

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -384,14 +384,14 @@ function(setup_target_for_coverage_lcov)
 
     # Show where to find the lcov info report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
+        COMMAND true
         COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
         ${GCOVR_XML_CMD_COMMENT}
     )
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
+        COMMAND true
         COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
     )
 
@@ -484,7 +484,7 @@ function(setup_target_for_coverage_gcovr_xml)
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
+        COMMAND true
         COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
     )
 endfunction() # setup_target_for_coverage_gcovr_xml
@@ -585,7 +585,7 @@ function(setup_target_for_coverage_gcovr_html)
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
+        COMMAND true
         COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
     )
 


### PR DESCRIPTION
This PR updates the code coverage module to follow `CMake` policy CMP0175. 

Policy CMP0175 was introduced in `CMake` 3.31. It prevents the use of `add_custom_command` with invalid arguments, such as an empty command. 

- https://cmake.org/cmake/help/latest/policy/CMP0175.html