### PR TITLE
Fixed a typo in command syntax for cppcheck

### DIFF
--- a/Findcppcheck.cmake
+++ b/Findcppcheck.cmake
@@ -102,7 +102,7 @@ if(CPPCHECK_EXECUTABLE)
     _cppcheck_set_arg_var(CPPCHECK_STYLE_ARG "--style")
     if("${CPPCHECK_STYLE_ARG}" STREQUAL "--enable=style")
 
-        _cppcheck_set_arg_var(CPPCHECK_UNUSEDFUNC_ARG "--enable=unusedFunctions")
+        _cppcheck_set_arg_var(CPPCHECK_UNUSEDFUNC_ARG "--enable=unusedFunction")
         _cppcheck_set_arg_var(CPPCHECK_INFORMATION_ARG "--enable=information")
         _cppcheck_set_arg_var(CPPCHECK_MISSINGINCLUDE_ARG "--enable=missingInclude")
         _cppcheck_set_arg_var(CPPCHECK_POSIX_ARG "--enable=posix")


### PR DESCRIPTION
Fixed a typo in command syntax for cppcheck, the correct command should be cppcheck --enable=unusedFunction and not --enable=unusedFunction**s**